### PR TITLE
Added Australia and New Zealand countries for Oceania

### DIFF
--- a/geographic_regions_by_country.csv
+++ b/geographic_regions_by_country.csv
@@ -235,6 +235,6 @@ SX,534,Sint Maarten (Dutch part),Caribbean,Americas,Developing_Nations,,Latin Am
 TT,780,Trinidad and Tobago,Caribbean,Americas,Developing_Nations,,Latin America and the Caribbean
 TC,796,Turks and Caicos Islands,Caribbean,Americas,Developing_Nations,,Latin America and the Caribbean
 VI,850,Virgin Islands,Caribbean,Americas,Developing_Nations,,Latin America and the Caribbean
-AU,036,Australia,,Oceania,Developed regions,,
-NZ,554,New Zealand,,Oceania,Developed regions,,
-NF,574,Norfolk Island,,Oceania,Developing_Nations,,
+AU,036,Australia,Australia and New Zealand,Oceania,Developed regions,,
+NZ,554,New Zealand,Australia and New Zealand,Oceania,Developed regions,,
+NF,574,Norfolk Island,Australia and New Zealand,Oceania,Developing_Nations,,

--- a/make_geographic_regions_csv.py
+++ b/make_geographic_regions_csv.py
@@ -55,6 +55,7 @@ un_regions = [
            'data/Countries_in_Micronesia.csv',
            'data/Countries_in_Polynesia.csv',
            'data/Countries_in_Caribbean.csv',
+           'data/Countries_in_Australia and New Zealand.csv',
 ]
 
 econ_groups = [


### PR DESCRIPTION
Added Australia and New Zealand countries for Oceania (missing previously). AU, NZ and NF country codes now have defined un_region fields in geographic_regions_by_country.csv
